### PR TITLE
Corrigir adição de eventos confirmados

### DIFF
--- a/app/src/main/java/com/pdm/zone/MainActivity.kt
+++ b/app/src/main/java/com/pdm/zone/MainActivity.kt
@@ -74,21 +74,3 @@ class MainActivity : ComponentActivity() {
         }
     }
 }
-
-@Composable
-fun HomePage() {
-    Column(
-        modifier = Modifier.fillMaxSize()
-            .background(Color.Blue)
-            .wrapContentSize(Alignment.Center)
-    ) {
-        Text(
-            text = "Home",
-            fontWeight = FontWeight.Bold,
-            color = Color.White,
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-            textAlign = TextAlign.Center,
-            fontSize = 20.sp
-        )
-    }
-}

--- a/app/src/main/java/com/pdm/zone/ui/nav/MainNavHost.kt
+++ b/app/src/main/java/com/pdm/zone/ui/nav/MainNavHost.kt
@@ -18,7 +18,7 @@ fun MainNavHost(
 ) {
     NavHost(navController, startDestination = "home") {
         composable("home") {
-            HomePage(navController)
+            HomePage(navController, eventViewModel)
         }
 
         composable("list") {

--- a/app/src/main/java/com/pdm/zone/ui/screens/event/EventDetails.kt
+++ b/app/src/main/java/com/pdm/zone/ui/screens/event/EventDetails.kt
@@ -43,26 +43,23 @@ fun EventDetailsPage(
     onConfirmPresence: (Event) -> Unit = {}
 ) {
     val currentUser by eventViewModel.currentUser
-
-    var displayEvent by remember {
-        mutableStateOf(
-            event ?: Event(
-                id = 1,
-                title = "Lorem ipsum dolor",
-                location = "Rua XXX, Várzea - Recife, PE",
-                dateTime = "21 de jun | 19h - 23h",
-                description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec augue a ligula iaculis aliquam in sit amet libero.",
-                imageRes = android.R.drawable.ic_menu_gallery,
-                category = "Evento",
-                attendees = listOf(),
-                confirmedCount = 30,
-                date = "21 de jun",
-                startTime = "19h",
-                endTime = "23h",
-                creatorId = "usuario_criador"
-            )
-        )
-    }
+    
+    // Buscar o evento mais atualizado do ViewModel
+    val currentEvent = eventViewModel.getEventById(eventId) ?: event ?: Event(
+        id = 1,
+        title = "Lorem ipsum dolor",
+        location = "Rua XXX, Várzea - Recife, PE",
+        dateTime = "21 de jun | 19h - 23h",
+        description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec augue a ligula iaculis aliquam in sit amet libero.",
+        imageRes = android.R.drawable.ic_menu_gallery,
+        category = "Evento",
+        attendees = listOf(),
+        confirmedCount = 30,
+        date = "21 de jun",
+        startTime = "19h",
+        endTime = "23h",
+        creatorId = "usuario_criador"
+    )
 
     Column(
         modifier = Modifier
@@ -103,7 +100,7 @@ fun EventDetailsPage(
                 .padding(16.dp)
         ) {
             Text(
-                text = displayEvent.title,
+                text = currentEvent.title,
                 fontSize = 30.sp,
                 fontWeight = FontWeight.Bold,
                 color = Primary
@@ -118,23 +115,21 @@ fun EventDetailsPage(
             ) {
                 Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                     Text(
-                        text = "${displayEvent.confirmedCount} Confirmados",
+                        text = "${currentEvent.confirmedCount} Confirmados",
                         fontSize = 12.sp,
                         color = Color.Gray
                     )
                 }
 
                 // Confirmar presença
-                val isConfirmed = currentUser.favoriteEvents.contains(displayEvent.id.toString())
+                val isConfirmed = currentUser.favoriteEvents.contains(currentEvent.id.toString())
 
                 IconButton(
                     onClick = {
                         if (isConfirmed) {
-                            eventViewModel.unconfirmEventPresence(displayEvent)
-                            displayEvent = displayEvent.copy(confirmedCount = displayEvent.confirmedCount - 1)
+                            eventViewModel.unconfirmEventPresence(currentEvent)
                         } else {
-                            eventViewModel.confirmEventPresence(displayEvent)
-                            displayEvent = displayEvent.copy(confirmedCount = displayEvent.confirmedCount + 1)
+                            eventViewModel.confirmEventPresence(currentEvent)
                         }
                     }
                 ) {
@@ -149,7 +144,7 @@ fun EventDetailsPage(
 
             // Descrição
             Text(
-                text = displayEvent.description,
+                text = currentEvent.description,
                 fontSize = 14.sp,
                 color = Color.Black,
                 lineHeight = 20.sp,
@@ -158,7 +153,7 @@ fun EventDetailsPage(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            EventInfoSection(event = displayEvent)
+            EventInfoSection(event = currentEvent)
 
             Spacer(modifier = Modifier.height(16.dp))
         }

--- a/app/src/main/java/com/pdm/zone/ui/screens/home/Home.kt
+++ b/app/src/main/java/com/pdm/zone/ui/screens/home/Home.kt
@@ -7,89 +7,12 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
-import com.pdm.zone.data.model.Event
 import com.pdm.zone.ui.components.EventCard
+import com.pdm.zone.viewmodel.EventViewModel
 
 @Composable
-fun HomePage(navController: NavHostController) {
-    val events = listOf(
-        Event(
-            id = 1,
-            title = "Noite do Karaokê",
-            location = "Estelita, Cabanga",
-            dateTime = "01/07 | 19h",
-            description = "Prepare-se para uma noite de karaokê emocionante e cheia de energia! Venha soltar a voz e mostrar seu talento musical na nossa casa! Noite do Karaokê. #Karaoke #NoiteDoKaraoke",
-            imageRes = android.R.drawable.ic_menu_gallery,
-            category = "Música",
-            attendees = listOf("João", "Maria", "Pedro", "Ana", "Carlos"),
-            confirmedCount = 30,
-            price = "$",
-            distance = "8.4 km",
-            date = "01/07",
-            startTime = "19h"
-        ),
-        Event(
-            id = 2,
-            title = "O Futuro nos Conecta",
-            location = "Recife, PE",
-            dateTime = "05/07 | 18h",
-            description = "Evento sobre tecnologia e inovação que vai mudar o futuro.",
-            imageRes = android.R.drawable.ic_menu_gallery,
-            category = "Tecnologia",
-            attendees = listOf("Tech", "Innovation", "Future"),
-            confirmedCount = 45,
-            price = "$",
-            distance = "2.5 km",
-            date = "05/07",
-            startTime = "18h"
-        ),
-        Event(
-            id = 3,
-            title = "Festival de Arte Urbana",
-            location = "Praça do Arsenal, Recife",
-            dateTime = "10/07 | 14h",
-            description = "Um festival ao ar livre com grafite, música e performance de artistas urbanos. Celebre a cultura de rua com arte e criatividade.",
-            imageRes = android.R.drawable.ic_menu_gallery,
-            category = "Arte",
-            attendees = listOf("Lucas", "Fernanda", "Aline"),
-            confirmedCount = 60,
-            price = "Gratuito",
-            distance = "1.1 km",
-            date = "10/07",
-            startTime = "14h"
-        ),
-        Event(
-            id = 4,
-            title = "Feira Vegana",
-            location = "Parque da Jaqueira, Recife",
-            dateTime = "12/07 | 10h",
-            description = "Uma feira com comidas veganas, cosméticos naturais e sustentabilidade. Perfeita para quem busca uma vida mais consciente.",
-            imageRes = android.R.drawable.ic_menu_gallery,
-            category = "Cultura",
-            attendees = listOf("Rafaela", "Caio", "Bianca", "Thiago"),
-            confirmedCount = 80,
-            price = "Gratuito",
-            distance = "3.2 km",
-            date = "12/07",
-            startTime = "10h"
-        ),
-        Event(
-            id = 5,
-            title = "Sarau de Poesia e Café",
-            location = "Café Literário, Boa Vista",
-            dateTime = "14/07 | 20h",
-            description = "Noite de poesias, declamações e um ambiente acolhedor com café e boas conversas. Traga seus versos ou apenas aprecie.",
-            imageRes = android.R.drawable.ic_menu_gallery,
-            category = "Literatura",
-            attendees = listOf("Júlia", "Enzo", "Sofia"),
-            confirmedCount = 25,
-            price = "R$ 10",
-            distance = "2.0 km",
-            date = "14/07",
-            startTime = "20h"
-        )
-    )
-
+fun HomePage(navController: NavHostController, eventViewModel: EventViewModel) {
+    val events = eventViewModel.allEvents
 
     Scaffold { innerPadding ->
         LazyColumn(

--- a/app/src/main/java/com/pdm/zone/viewmodel/EventViewModel.kt
+++ b/app/src/main/java/com/pdm/zone/viewmodel/EventViewModel.kt
@@ -11,6 +11,89 @@ class EventViewModel : ViewModel() {
     private val _confirmedEvents = mutableStateOf<List<Event>>(emptyList())
     val confirmedEvents: List<Event> get() = _confirmedEvents.value
 
+    // Lista de todos os eventos disponíveis
+    private val _allEvents = mutableStateOf<List<Event>>(
+        listOf(
+            Event(
+                id = 1,
+                title = "Noite do Karaokê",
+                location = "Estelita, Cabanga",
+                dateTime = "01/07 | 19h",
+                description = "Prepare-se para uma noite de karaokê emocionante e cheia de energia! Venha soltar a voz e mostrar seu talento musical na nossa casa! Noite do Karaokê. #Karaoke #NoiteDoKaraoke",
+                imageRes = android.R.drawable.ic_menu_gallery,
+                category = "Música",
+                attendees = listOf("João", "Maria", "Pedro", "Ana", "Carlos"),
+                confirmedCount = 30,
+                price = "$",
+                distance = "8.4 km",
+                date = "01/07",
+                startTime = "19h"
+            ),
+            Event(
+                id = 2,
+                title = "O Futuro nos Conecta",
+                location = "Recife, PE",
+                dateTime = "05/07 | 18h",
+                description = "Evento sobre tecnologia e inovação que vai mudar o futuro.",
+                imageRes = android.R.drawable.ic_menu_gallery,
+                category = "Tecnologia",
+                attendees = listOf("Tech", "Innovation", "Future"),
+                confirmedCount = 45,
+                price = "$",
+                distance = "2.5 km",
+                date = "05/07",
+                startTime = "18h"
+            ),
+            Event(
+                id = 3,
+                title = "Festival de Arte Urbana",
+                location = "Praça do Arsenal, Recife",
+                dateTime = "10/07 | 14h",
+                description = "Um festival ao ar livre com grafite, música e performance de artistas urbanos. Celebre a cultura de rua com arte e criatividade.",
+                imageRes = android.R.drawable.ic_menu_gallery,
+                category = "Arte",
+                attendees = listOf("Lucas", "Fernanda", "Aline"),
+                confirmedCount = 60,
+                price = "Gratuito",
+                distance = "1.1 km",
+                date = "10/07",
+                startTime = "14h"
+            ),
+            Event(
+                id = 4,
+                title = "Feira Vegana",
+                location = "Parque da Jaqueira, Recife",
+                dateTime = "12/07 | 10h",
+                description = "Uma feira com comidas veganas, cosméticos naturais e sustentabilidade. Perfeita para quem busca uma vida mais consciente.",
+                imageRes = android.R.drawable.ic_menu_gallery,
+                category = "Cultura",
+                attendees = listOf("Rafaela", "Caio", "Bianca", "Thiago"),
+                confirmedCount = 80,
+                price = "Gratuito",
+                distance = "3.2 km",
+                date = "12/07",
+                startTime = "10h"
+            ),
+            Event(
+                id = 5,
+                title = "Sarau de Poesia e Café",
+                location = "Café Literário, Boa Vista",
+                dateTime = "14/07 | 20h",
+                description = "Noite de poesias, declamações e um ambiente acolhedor com café e boas conversas. Traga seus versos ou apenas aprecie.",
+                imageRes = android.R.drawable.ic_menu_gallery,
+                category = "Literatura",
+                attendees = listOf("Júlia", "Enzo", "Sofia"),
+                confirmedCount = 25,
+                price = "R$ 10",
+                distance = "2.0 km",
+                date = "14/07",
+                startTime = "20h"
+            )
+        )
+    )
+    
+    val allEvents: List<Event> get() = _allEvents.value
+
     private val _currentUser = mutableStateOf(
         User(
             uid = "1",
@@ -29,15 +112,31 @@ class EventViewModel : ViewModel() {
 
     val currentUser: State<User> get() = _currentUser
 
+    // Buscar evento por ID
+    fun getEventById(eventId: Int): Event? {
+        return _allEvents.value.find { it.id == eventId }
+    }
+
     fun confirmEventPresence(event: Event) {
         val isAlreadyConfirmed = _currentUser.value.favoriteEvents.contains(event.id.toString())
 
         if (!isAlreadyConfirmed) {
+            // Atualizar lista de eventos favoritos do usuário
             _currentUser.value = _currentUser.value.copy(
                 favoriteEvents = _currentUser.value.favoriteEvents + event.id.toString()
             )
 
-            _confirmedEvents.value = _confirmedEvents.value + event
+            // Atualizar contador do evento na lista principal
+            _allEvents.value = _allEvents.value.map { 
+                if (it.id == event.id) {
+                    it.copy(confirmedCount = it.confirmedCount + 1)
+                } else {
+                    it
+                }
+            }
+
+            // Adicionar evento à lista de confirmados
+            _confirmedEvents.value = _confirmedEvents.value + event.copy(confirmedCount = event.confirmedCount + 1)
         }
     }
 
@@ -45,10 +144,21 @@ class EventViewModel : ViewModel() {
         val isConfirmed = _currentUser.value.favoriteEvents.contains(event.id.toString())
 
         if (isConfirmed) {
+            // Remover da lista de eventos favoritos do usuário
             _currentUser.value = _currentUser.value.copy(
                 favoriteEvents = _currentUser.value.favoriteEvents - event.id.toString()
             )
 
+            // Atualizar contador do evento na lista principal
+            _allEvents.value = _allEvents.value.map { 
+                if (it.id == event.id) {
+                    it.copy(confirmedCount = maxOf(0, it.confirmedCount - 1))
+                } else {
+                    it
+                }
+            }
+
+            // Remover evento da lista de confirmados
             _confirmedEvents.value = _confirmedEvents.value.filter { it.id != event.id }
         }
     }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Corrige a adição/remoção de eventos confirmados e a atualização do contador ao clicar no ícone de coração.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
A implementação anterior não sincronizava corretamente o estado dos eventos confirmados entre as telas devido a dados descentralizados e variáveis locais que não refletiam as mudanças globais. Esta PR centraliza os eventos no `EventViewModel` e garante que todas as telas referenciem a mesma fonte de dados, permitindo atualizações em tempo real e persistência do estado de confirmação.